### PR TITLE
Grammar and spelling fixes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ Clementine
 Description
 -----------
 
-Clementine is a gem to use ClojureScript (https://github.com/clojure/clojurescript) from Ruby.
-Clementine is a Tilt (https://github.com/rtomayko/tilt) Template, which is available to use
-on Rails asset pipeline. Also, it is avilable to use in a Tilt way.
-You don't need to compile ClojureScript by yourself anymore. Clementine does for you.
+Clementine is a gem to use ClojureScript (https://github.com/clojure/clojurescript) in Ruby projects.
+Clementine is a Tilt (https://github.com/rtomayko/tilt) Template, which works with Tilt on its own, as well as the Rails asset pipeline.
+
+You don't need to compile ClojureScript by yourself anymore. Clementine does this for you.
 
 Clementine runs on Rails 3.1 and later.
 
 Clementine supports JRuby and CRuby. When you use from CRuby, make sure java command is on your PATH.
 
-Please be aware. When you run Clementine on CRuby, you hook up JVM everytime ClojureScript code is changed.
+Please be aware, when you run Clementine on CRuby, you hook up the JVM everytime ClojureScript code is changed.
 This takes long time since starting JVM is a heavy weight job.
-For a shorter compilation time, I recommend using JRuby.
+For a shorter compilation time, JRuby is recommended.
 
 Installation
 -----------
@@ -27,8 +27,8 @@ Installation
 gem install clementine
 ```
 
-While installing this gem, you'll see a confusing phrase, "Installing clementine (version string) with native extensions."
-This means clementine is bootstrapping ClojureScript. Clementine never relies on any C library.
+While installing this gem, you'll see a confusing phrase, "Installing Clementine (version string) with native extensions."
+This means Clementine is bootstrapping ClojureScript. Clementine never relies on any C library.
 
 Configuration
 -----------
@@ -56,12 +56,12 @@ Available options:
 
 *note*<br/>
 If you want to see a readable JavaScript code on the browser,
-set :whitespace for :optimazations and true for :pretty_print in
+set :whitespace for :optimizations and true for :pretty_print in
 ${Rails.root}/config/initializer/clementine.rb like the example above.
 
 *note*<br/>
-ClojureScript has :none value for :optimizations, which also works with Clementine.
-However, there's no way to see the output with Rails asset pipeline.
+ClojureScript has a :none value for :optimizations, which also works with Clementine.
+However, there's no way to see the output with the Rails asset pipeline.
 So, I didn't add :none in the above table.
 
 Copyright and License


### PR DESCRIPTION
Noticed that optimizations was misspelled and did a quick editing pass. Thanks for making Clementine, Yoko!
